### PR TITLE
Update sqlQueryApi.py

### DIFF
--- a/apps/query/sqlQueryApi.py
+++ b/apps/query/sqlQueryApi.py
@@ -51,7 +51,7 @@ class MySQLQueryApi(object):
                               port=self.local_port,
                               database=self.local_schema,
                               max_allowed_packet=1024 * 1024 * 1024,
-                              charset='utf8',
+                              charset='utf8mb4',
                               cursorclass=pymysql.cursors.DictCursor)
         return cnx
 


### PR DESCRIPTION
查询字符集由utf8改为utf8mb4，修复utf8mb4查询乱码的问题